### PR TITLE
Use a JSON string for the orderbook price in order to avoid the rounding errors

### DIFF
--- a/docs/basic-docs/atomicdex/atomicdex-api.md
+++ b/docs/basic-docs/atomicdex/atomicdex-api.md
@@ -2215,36 +2215,36 @@ The `orderbook` method requests from the network the currently available orders 
 
 #### Arguments
 
-| Structure | Type     | Description |
-| --------- | -------- | ----------- |
-| base       | string | base currency of a pair |
+| Structure | Type   | Description |
+| --------- | ------ | ----------- |
+| base      | string | base currency of a pair |
 | rel       | string | "related" currency, also can be called "quote currency" according to exchange terms |
 | duration  | number | `deprecated` |
 
 #### Response
 
-| Structure | Type     | Description |
-| --------- | -------- | ----------- |
-| bids | array | an array of objects containing outstanding bids (from Alice nodes) |
-| numbids | number | the number of outstanding bids |
-| biddepth | number | `deprecated` |
-| asks | array | an array of objects containing outstanding asks (from Bob nodes) |
-| coin | string | the name of the `base` coin; the user desires this |
-| address | string | the address offering the trade |
-| price     | number | the price in `rel` the user is willing to pay per one unit of the `base` coin |
-| numutxos | number | `deprecated` the number of utxos the offer provider has in their wallet |
-| avevolume | number | `deprecated` the average volume of `coin` per utxo |
-| maxvolume | number | the total amount of `base` coins the offer provider has in their wallet |
-| depth | number | `deprecated` |
-| pubkey | string | the pubkey of the offer provider |
-| age | number | the age of the offer |
-| zcredits | number | the zeroconf deposit amount |
-| numasks | number | the total number of asks |
-| askdepth | number | the depth of the ask requests |
-| base | string | the name of the coin the user desires to receive |
-| rel | string | the name of the coin the user will trade |
-| timestamp | number | the timestamp of the orderbook request |
-| netid | number | the id of the network on which the request is made (default is `0`) |
+| Structure | Type             | Description |
+| --------- | ---------------- | ----------- |
+| bids      | array            | an array of objects containing outstanding bids (from Alice nodes) |
+| numbids   | number           | the number of outstanding bids |
+| biddepth  | number           | `deprecated` |
+| asks      | array            | an array of objects containing outstanding asks (from Bob nodes) |
+| coin      | string           | the name of the `base` coin; the user desires this |
+| address   | string           | the address offering the trade |
+| price     | string (decimal) | the price in `rel` the user is willing to pay per one unit of the `base` coin |
+| numutxos  | number           | `deprecated` the number of utxos the offer provider has in their wallet |
+| avevolume | number           | `deprecated` the average volume of `coin` per utxo |
+| maxvolume | number           | the total amount of `base` coins the offer provider has in their wallet |
+| depth     | number           | `deprecated` |
+| pubkey    | string           | the pubkey of the offer provider |
+| age       | number           | the age of the offer |
+| zcredits  | number           | the zeroconf deposit amount |
+| numasks   | number           | the total number of asks |
+| askdepth  | number           | the depth of the ask requests |
+| base      | string           | the name of the coin the user desires to receive |
+| rel       | string           | the name of the coin the user will trade |
+| timestamp | number           | the timestamp of the orderbook request |
+| netid     | number           | the id of the network on which the request is made (default is `0`) |
 
 #### :pushpin: Examples
 
@@ -2269,7 +2269,7 @@ curl --url "http://127.0.0.1:7783" --data "{\"userpass\":\"$userpass\",\"method\
     {
       "coin": "HELLO",
       "address": "RJTYiYeJ8eVvJ53n2YbrVmxWNNMVZjDGLh",
-      "price": 0.89999998,
+      "price": "0.89999998",
       "numutxos": 0,
       "avevolume": 0,
       "maxvolume": 10855.85028615,


### PR DESCRIPTION
cf. https://github.com/KomodoPlatform/atomicDEX-API/issues/495