### PR TITLE
A little typo in the command to run the container

### DIFF
--- a/docs/basic-docs/antara/antara-tutorials/beginner-series-part-0.md
+++ b/docs/basic-docs/antara/antara-tutorials/beginner-series-part-0.md
@@ -182,7 +182,7 @@ Start the container.
 This drops into a bash prompt that is ready to start the guided tutorials.
 
 ```bash
-docker run -it -p 127.0.0.1:9253:9253 komodocakeshop/dev-allininone-learn-kmd
+docker run -it -p 127.0.0.1:9253:9253 komodocakeshop/dev-allinone-learn-kmd
 ```
 
 #### (Optional, for Smaller Docker Image Only) Mount the Local Zcash Parameters


### PR DESCRIPTION
Repository was typed wrongly.