### PR TITLE
update enable method: manual importaddress

### DIFF
--- a/docs/basic-docs/atomicdex/atomicdex-api.md
+++ b/docs/basic-docs/atomicdex/atomicdex-api.md
@@ -527,7 +527,12 @@ The `enable` method enables a coin by connecting the user's software instance to
 
 Each `coin` can be enabled only once, and in either Electrum or Native mode. The DEX software does not allow a `coin` to be active in both modes at once.
 
-For utxo-based coins the daemon of this blockchain must also be running on the user's machine for `enable` to function.
+For utxo-based coins the daemon of this blockchain must also be running on the user's machine for `enable` to function. 
+
+::: tip Note
+The MM2 node's coin address needs to be imported manually into the coin daemon using the [importaddress](../../../basic-docs/smart-chains/smart-chain-api/wallet.html#importaddress) call.
+
+:::
 
 ETH/ERC20 coins are also enabled by the `enable` method, but a local installation of an ETH node is not required.
 


### PR DESCRIPTION
Per the discord question here: https://discordapp.com/channels/412898016371015680/449950331577565194/659292649437528114

In contrast with mm1.0, mm2.0 does not automatically import the address in the coin's daemon, when MM2.0 is used in native mode.
The docs should include this information.