### PR TITLE
MmRPC Protocol v2.0

### DIFF
--- a/docs/.vuepress/atomicDEX-sidebar.js
+++ b/docs/.vuepress/atomicDEX-sidebar.js
@@ -93,6 +93,24 @@ let atomicDEXsidebar = {
         ],
       ],
     },
+    {
+      title: "AtomicDEX API 2.0",
+      collapsible: true,
+      children: [
+        [
+          "/basic-docs/atomicdex/atomicdex-api-20/mmrpc-20.md",
+          "MmRPC Protocol v2.0",
+        ],
+        [
+          "/basic-docs/atomicdex/atomicdex-api-20/trade_preimage.md",
+          "trade_preimage",
+        ],
+        [
+          "/basic-docs/atomicdex/atomicdex-api-20/withdraw.md",
+          "withdraw",
+        ],
+      ],
+    },
     ["/basic-docs/atomicdex/atomicdex-api.md", "AtomicDEX API"],
   ],
 };

--- a/docs/basic-docs/atomicdex/atomicdex-api-20/mmrpc-20.md
+++ b/docs/basic-docs/atomicdex/atomicdex-api-20/mmrpc-20.md
@@ -1,0 +1,88 @@
+# MarketMaker RPC Protocol v2.0
+
+Starting with version [beta-2.1.3434](https://github.com/KomodoPlatform/atomicDEX-API/releases/tag/beta-2.1.3434), MarketMaker supports the standardized protocol format called `mmrpc 2.0`.
+
+It includes a uniform request, successful and error response formats.
+
+At the moment, only a few RPC methods support the `mmrpc 2.0` protocol, such as **withdraw** and **trade_preimage**.
+
+### Request
+
+| Structure       | Type                       | Description                                                                                                                                                       |
+| --------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mmrpc           | string                     | the string specifying the version of the MarketMaker RPC protocol. Must be exactly "2.0"                                                                          |
+| userpass        | string (optional)          | your password for protected RPC methods. Skip this field if the specified `method` is public                                                                      |
+| method          | string                     | the name of the method to be invoked                                                                                                                              |
+| params          | object (optional)          | a structured value that holds the parameter values to be used during the invocation of the method. This field may be omitted if the method doesn't take arguments |
+| id              | number (optional)          | the identifier is established by the client. MarketMaker will reply with the same value in the Response object if the `id` field is included and not `NULL`        |
+
+### Response (Success)
+
+| Structure       | Type                       | Description                                                                                                                                                       |
+| --------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mmrpc           | string                     | the string specifying the version of the MarketMaker RPC protocol                                                                                                 |
+| result          | object                     | the value of this field is determined by the method invoked on MarketMaker                                                                                        |
+| id              | number (optional)          | the identifier established by the client. The same value as in the Request if it was passed                                                                     |
+
+### Response (Error)
+
+| Structure       | Type                       | Description                                                                                                                                                       |
+| --------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| mmrpc           | string                     | the string specifying the version of the MarketMaker RPC protocol                                                                                                 |
+| error           | string                     | the common error description                                                                                                                                      |
+| error_path      | string                     | the error path consisting of file names separated by a dot similar to JSON path notation                                                                          |
+| error_trace     | string                     | the error path consisting of file and line number pairs separated by ']'                                                                                          |
+| error_type      | string                     | the string error identifier used to determine the cause of the error                                                                                         |
+| error_data      | object                     | an object containing the error data of the corresponding `error_type`                                                                                             |
+| id              | number (optional)          | the identifier established by the client. The same value as in the Request if it was passed                                                                     |
+
+### :pushpin: Examples
+
+#### Command
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"KMD\",\"to\":\"RJTYiYeJ8eVvJ53n2YbrVmxWNNMVZjDGLh\",\"amount\":\"10\"},\"id\":0}"
+```
+
+#### Response (success)
+
+```json
+{
+  "mmrpc": "2.0",
+  "result": {
+    "tx_hex": "0400008085202f8901ef25b1b7417fe7693097918ff90e90bba1351fff1f3a24cb51a9b45c5636e57e010000006b483045022100b05c870fcd149513d07b156e150a22e3e47fab4bb4776b5c2c1b9fc034a80b8f022038b1bf5b6dad923e4fb1c96e2c7345765ff09984de12bbb40b999b88b628c0f9012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff0200e1f505000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac8cbaae5f010000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ace87a5e5d000000000000000000000000000000",
+    "tx_hash": "1ab3bc9308695960bc728fa427ac00d1812c4ae89aaa714c7618cb96d111be58",
+    "from": ["R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"],
+    "to": ["R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"],
+    "total_amount": "60.10253836",
+    "spent_by_me": "60.10253836",
+    "received_by_me": "60.00253836",
+    "my_balance_change": "-0.1",
+    "block_height": 0,
+    "timestamp": 1566472936,
+    "fee_details": {
+      "type": "Utxo",
+      "amount": "0.1"
+    },
+    "coin": "RICK",
+    "internal_id": ""
+  },
+  "id": 0
+}
+```
+
+#### Response (error)
+
+```json
+{
+  "mmrpc": "2.0",
+  "error": "The amount 0.000005 is too small",
+  "error_path": "utxo_common",
+  "error_trace": "utxo_common:1379] utxo_common:301]",
+  "error_type": "AmountIsTooSmall",
+  "error_data": {
+    "amount":"0.000005"
+  },
+  "id":0
+}
+```

--- a/docs/basic-docs/atomicdex/atomicdex-api-20/trade_preimage.md
+++ b/docs/basic-docs/atomicdex/atomicdex-api-20/trade_preimage.md
@@ -1,0 +1,525 @@
+# trade\_preimage
+
+The `trade_preimage` method returns the approximate fee amounts that are paid per the whole swap.
+Depending on the parameters, the function returns different results:
+
+- If the `swap_method` is `buy` or `sell`, then the result will include the `taker_fee` and the `fee_to_send_taker_fee`.
+  The `taker_fee` amount is paid from the `base` coin balance if the `swap_method` is `sell`, else it is paid from the `rel` coin balance;
+- If the `max` field is true, then the result will include the `volume`.
+
+::: tip Note
+
+This method can be used instead of **max_taker_vol**, if the `max` field is true and the `swap_method` is `buy` or `sell`.
+Use the resulting `volume` as an argument of the `buy` or `sell` requests.
+
+:::
+
+::: warning Important
+
+Use the `trade_preimage` request with `max = true` and `swap_method = "setprice"` arguments to approximate the fee amounts **only**. Do not use the resulting `volume` as an argument of the `setprice`.
+
+:::
+
+### Arguments
+
+| Structure   | Type                                  | Description                                                                                                                          |
+| ----------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| base        | string                                | the base currency of the request                                                                                                     |
+| rel         | string                                | the rel currency of the request                                                                                                      |
+| swap_method | string                                | the name of the method whose preimage is requested. Possible values: `buy`, `sell`, `setprice`                                       |
+| price       | numeric string or rational            | the price in `rel` the user is willing to pay per one unit of the `base` coin                                                        |
+| volume      | numeric string or rational (optional) | the amount the user is willing to trade; ignored if `max = true` **and** `swap_method = setprice`, otherwise, it must be set         |
+| max         | bool (optional)                       | whether to return the maximum available volume for `setprice` method; must not be set or `false` if `swap_method` is `buy` or `sell` |
+
+### Result
+
+| Structure                                    | Type                                 | Description                                                                                                                                    |
+| -------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| result                                       | object                               | an object containing the relevant information                                                                                                  |
+| result.base_coin_fee                         | object (`ExtendedFeeInfo`)           | the approximate miner fee is paid per the whole swap concerning the `base` coin                                                                |
+| result.rel_coin_fee                          | object (`ExtendedFeeInfo`)           | the approximate miner fee is paid per the whole swap concerning the `rel` coin                                                                 |
+| result.volume                                | string (numeric, optional)           | the max available volume that can be traded (in decimal representation); empty if the `max` argument is missing or false                       |
+| result.volume_rat                            | rational (optional)                  | the max available volume that can be traded (in rational representation); empty if the `max` argument is missing or false                      |
+| result.volume_fraction                       | fraction (optional)                  | the max available volume that can be traded (in fraction representation); empty if the `max` argument is missing or false                      |
+| result.taker_fee                             | object (optional, `ExtendedFeeInfo`) | the dex fee to be paid by Taker; empty if `swap_method` is `setprice`                                                                          |
+| result.fee_to_send_taker_fee                 | object (optional, `ExtendedFeeInfo`) | the approximate miner fee is paid to send the dex fee; empty if `swap_method` is `setprice`                                                    |
+| result.total_fees                            | array of `ExtendedFeeInfo` objects   | each element is a sum of fees required to be paid from user's balance of corresponding `ExtendedFeeInfo.coin`; the elements are unique by coin |
+
+Where the `ExtendedFeeInfo` has
+
+| Structure       | Type             | Description                                                                                                                                                   |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| coin            | string           | the fee is paid from the user's balance of this coin. This coin name may differ from the `base` or `rel` coins. For example, ERC20 fees are paid by ETH (gas) |
+| amount          | string (numeric) | fee amount (in decimal representation)                                                                                                                        |
+| amount_rat      | rational         | fee amount (in rational representation)                                                                                                                       |
+| amount_fraction | fraction         | fee amount (in fraction representation)                                                                                                                       |
+
+### :warning: Error types
+
+#### NotSufficientBalance
+
+The `available` balance of the `coin` is not sufficient to start the swap.
+
+| Structure       | Type                       | Description                                                                                |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------ |
+| coin            | string                     | the name of the coin which balance is not sufficient                                       |
+| available       | string (numeric)           | the balance available for swap, including the amount locked by other swaps                 |
+| required        | string (numeric)           | the amount required to start the swap. This amount is necessary but may not be sufficient  |
+| locked_by_swaps | string (numeric, optional) | the amount locked by other swaps                                                        |
+
+#### NotSufficientBaseCoinBalance
+
+The available balance of the base `coin` is not sufficient to pay transaction fees.
+
+For example, ERC20 fees are paid by ETH (gas), and this error type is returned if the ETH coin balance is not sufficient to start the swap.
+
+| Structure       | Type                       | Description                                                                                |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------ |
+| coin            | string                     | the name of the base coin which balance is not sufficient                                  |
+| available       | string (numeric)           | the balance available for swap, including the amount locked by other swaps                 |
+| required        | string (numeric)           | the amount required to start the swap. This amount is necessary but may not be sufficient |
+| locked_by_swaps | string (numeric, optional) | the amount is locked by other swaps                                                        |
+
+#### VolumeTooLow
+
+The specified `volume` is too low. Required at least `threshold`.
+
+::: tip Note
+
+If the `coin` field returned in Response is the same as the `rel` argument in Request, then the base volume threshold can be calculated as follows:
+`base_coin_threshold = rel_vol_threshold / price`
+
+:::
+
+| Structure | Type             | Description                                        |
+| --------- | ---------------- | -------------------------------------------------- |
+| coin      | string           | either `base` or `rel` coin specified in Request   |
+| volume    | string (numeric) | the amount the user was willing to trade in `coin` |
+| threshold | string (numeric) | the `volume` has not to be less than this amount   |
+
+#### NoSuchCoin
+
+The specified coin was not found or is not activated yet.
+
+| Structure | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| coin      | string | either `base` or `rel` coin specified in Request |
+
+#### CoinIsWalletOnly
+
+The specified coin is wallet only and cannot be participated in the swap.
+
+| Structure | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| coin      | string | either `base` or `rel` coin specified in Request |
+
+#### BaseEqualRel
+
+The coin is wallet only and cannot be participated in the swap.
+
+| Structure | Type   | Description |
+| --------- | ------ | ----------- |
+| (none)    |        |             |
+
+#### InvalidParam
+
+Incorrect use of the `param` parameter in Request.
+
+| Structure | Type   | Description                                      |
+| --------- | ------ | ------------------------------------------------ |
+| param     | string | the name of the parameter in Request             |
+| reason    | string | the reason why the parameter is used incorrectly |
+
+#### PriceTooLow
+
+The specified `price` is too low.
+
+| Structure | Type             | Description                                                                        |
+| --------- | ---------------- | ---------------------------------------------------------------------------------- |
+| price     | string (numeric) | the price in `rel` the user was willing to receive per one unit of the `base` coin |
+| threshold | string (numeric) | the `price` has not to be less than this amount                                    |
+
+#### Transport
+
+The request was failed due to a network error.
+
+| Structure | Type   | Description                     |
+| --------- | ------ | ------------------------------- |
+| (none)    | string | the transport error description |
+
+#### InternalError
+
+The request was failed due to a MarketMaker internal error.
+
+| Structure | Type   | Description                    |
+| --------- | ------ | ------------------------------ |
+| (none)    | string | the internal error description |
+
+### :pushpin: Examples
+
+#### Command (setprice)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"trade_preimage\",\"params\":{\"base\":\"BTC\",\"rel\":\"RICK\",\"price\":\"1\",\"volume\":\"0.1\",\"swap_method\":\"setprice\"},\"id\":0}"
+```
+
+#### Response
+
+```json
+{
+  "mmrpc": "2.0",
+  "result": {
+    "base_coin_fee": {
+      "amount": "0.00042049",
+      "amount_fraction": {
+        "denom": "100000000",
+        "numer": "42049"
+      },
+      "amount_rat": [ [ 1, [ 42049 ] ], [ 1, [ 100000000 ] ] ],
+      "coin": "BTC",
+      "paid_from_trading_vol": false
+    },
+    "rel_coin_fee": {
+      "coin": "RICK",
+      "amount": "0.00001",
+      "amount_fraction": {
+        "numer": "1",
+        "denom": "100000"
+      },
+      "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 100000 ] ] ],
+      "paid_from_trading_vol": true
+    },
+    "total_fees": [
+      {
+        "coin": "RICK",
+        "amount": "0.00001",
+        "amount_fraction": {
+          "numer": "1",
+          "denom": "100000"
+        },
+        "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 100000 ] ] ],
+        "required_balance": "0",
+        "required_balance_fraction": {
+          "numer": "0",
+          "denom": "1"
+        },
+        "required_balance_rat": [ [ 0, [] ], [ 1, [ 1 ] ] ]
+      },
+      {
+        "coin": "BTC",
+        "amount": "0.00042049",
+        "amount_fraction": {
+          "denom": "100000000",
+          "numer": "42049"
+        },
+        "amount_rat": [ [ 1, [ 42049 ] ], [ 1, [ 100000000 ] ] ],
+        "required_balance": "0.00042049",
+        "required_balance_fraction": {
+          "denom": "100000000",
+          "numer": "42049"
+        },
+        "required_balance_rat": [ [ 1, [ 42049 ] ], [ 1, [ 100000000 ] ] ]
+      }
+    ]
+  },
+  "id": 0
+}
+```
+
+#### Command (buy)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"trade_preimage\",\"params\":{\"base\":\"BTC\",\"rel\":\"RICK\",\"price\":\"1\",\"volume\":\"0.1\",\"swap_method\":\"buy\"},\"id\":0}"
+```
+
+#### Response
+
+```json
+{
+  "mmrpc": "2.0",
+  "result": {
+    "base_coin_fee": {
+      "amount": "0.00042049",
+      "amount_fraction": {
+        "denom": "100000000",
+        "numer": "42049"
+      },
+      "amount_rat": [ [ 1, [ 42049 ] ], [ 1, [ 100000000 ] ] ],
+      "coin": "BTC",
+      "paid_from_trading_vol": true
+    },
+    "rel_coin_fee": {
+      "amount": "0.0001",
+      "amount_fraction": {
+        "denom": "10000",
+        "numer": "1"
+      },
+      "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 10000 ] ] ],
+      "coin": "RICK",
+      "paid_from_trading_vol": false
+    },
+    "taker_fee": {
+      "amount": "0.00012870012870012872",
+      "amount_fraction": {
+        "denom": "7770",
+        "numer": "1"
+      },
+      "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 7770 ] ] ],
+      "coin": "RICK",
+      "paid_from_trading_vol": false
+    },
+    "fee_to_send_taker_fee": {
+      "amount": "0.0001",
+      "amount_fraction": {
+        "denom": "10000",
+        "numer": "1"
+      },
+      "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 10000 ] ] ],
+      "coin": "RICK",
+      "paid_from_trading_vol": false
+    },
+    "total_fees": [
+      {
+        "coin": "RICK",
+        "amount": "0.001307001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287",
+        "amount_fraction": {
+          "numer": "50777",
+          "denom": "38850000"
+        },
+        "amount_rat": [ [ 1, [ 50777 ] ], [ 1, [ 38850000 ] ] ],
+        "required_balance": "0.001307001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287001287",
+        "required_balance_fraction": {
+          "numer": "50777",
+          "denom": "38850000"
+        },
+        "required_balance_rat": [ [ 1, [ 50777 ] ], [ 1, [ 38850000 ] ] ]
+      },
+      {
+        "coin": "tBTC",
+        "amount": "0.00042049",
+        "amount_fraction": {
+          "denom": "100000000",
+          "numer": "42049"
+        },
+        "amount_rat": [ [ 1, [ 42049 ] ], [ 1, [ 100000000 ] ] ],
+        "required_balance": "0",
+        "required_balance_fraction": {
+          "numer": "0",
+          "denom": "1"
+        },
+        "required_balance_rat": [ [ 0, [] ], [ 1, [ 1 ] ] ]
+      }
+    ]
+  },
+  "id": 0
+}
+```
+
+#### Command (sell, max)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"trade_preimage\",\"params\":{\"base\":\"BTC\",\"rel\":\"RICK\",\"price\":\"1\",\"volume\":\"2.21363478\",\"swap_method\":\"sell\"},\"id\":0}"
+```
+
+#### Response
+
+```json
+{
+  "mmrpc": "2.0",
+  "result": {
+    "base_coin_fee": {
+      "amount": "0.00042049",
+      "amount_fraction": {
+        "denom": "100000000",
+        "numer": "42049"
+      },
+      "amount_rat": [ [ 1, [ 42049 ] ], [ 1, [ 100000000 ] ] ],
+      "coin": "BTC",
+      "paid_from_trading_vol": false
+    },
+    "rel_coin_fee": {
+      "coin": "RICK",
+      "amount": "0.00001",
+      "amount_fraction": {
+        "numer": "1",
+        "denom": "100000"
+      },
+      "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 100000 ] ] ],
+      "paid_from_trading_vol": true
+    },
+    "taker_fee": {
+      "amount": "0.0028489508108108107",
+      "amount_fraction": {
+        "denom": "1850000000",
+        "numer": "5270559"
+      },
+      "amount_rat": [ [ 1, [ 5270559 ] ], [ 1, [ 1850000000 ] ] ],
+      "coin": "BTC",
+      "paid_from_trading_vol": false
+    },
+    "fee_to_send_taker_fee": {
+      "amount": "0.00033219",
+      "amount_fraction": {
+        "denom": "100000000",
+        "numer": "33219"
+      },
+      "amount_rat": [ [ 1, [ 33219 ] ], [ 1, [ 100000000 ] ] ],
+      "coin": "BTC",
+      "paid_from_trading_vol": false
+    },
+    "total_fees": [
+      {
+        "coin": "RICK",
+        "amount": "0.00001",
+        "amount_fraction": {
+          "numer": "1",
+          "denom": "100000"
+        },
+        "amount_rat": [ [ 1, [ 1 ] ], [ 1, [ 100000 ] ] ],
+        "required_balance": "0",
+        "required_balance_fraction": {
+          "numer": "0",
+          "denom": "1"
+        },
+        "required_balance_rat": [ [ 0, [] ], [ 1, [ 1 ] ] ]
+      },
+      {
+        "coin": "BTC",
+        "amount": "0.0036016308108108106",
+        "amount_fraction": {
+          "denom": "1850000000",
+          "numer": "6663017"
+        },
+        "amount_rat": [ [ 1, [ 6663017 ] ], [ 1, [ 1850000000 ] ] ],
+        "required_balance": "0.0036016308108108106",
+        "required_balance_fraction": {
+          "denom": "1850000000",
+          "numer": "6663017"
+        },
+        "required_balance_rat": [ [ 1, [ 6663017 ] ], [ 1, [ 1850000000 ] ] ]
+      }
+    ]
+  },
+  "id": 0
+}
+```
+
+#### Command (ERC20 and QRC20)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"trade_preimage\",\"params\":{\"base\":\"BAT\",\"rel\":\"QC\",\"price\":\"1\",\"volume\":\"2.21363478\",\"swap_method\":\"setprice\"},\"id\":0}"
+```
+
+#### Response
+
+```json
+{
+  "mmrpc": "2.0",
+  "result": {
+    "base_coin_fee": {
+      "amount": "0.0045",
+      "amount_fraction": {
+        "denom": "2000",
+        "numer": "9"
+      },
+      "amount_rat": [ [ 1, [ 9 ] ], [ 1, [ 2000 ] ] ],
+      "coin": "ETH",
+      "paid_from_trading_vol": false
+    },
+    "rel_coin_fee": {
+      "amount": "0.00325",
+      "amount_fraction": {
+        "denom": "4000",
+        "numer": "13"
+      },
+      "amount_rat": [ [ 0, [ 13 ] ], [ 1, [ 4000 ] ] ],
+      "coin": "QTUM",
+      "paid_from_trading_vol": false
+    },
+    "total_fees": [
+      {
+        "amount": "0.003",
+        "amount_fraction": {
+          "denom": "1000",
+          "numer": "3"
+        },
+        "amount_rat": [ [ 1, [ 3 ] ], [ 1, [ 1000 ] ] ],
+        "required_balance": "0.003",
+        "required_balance_fraction": {
+          "denom": "1000",
+          "numer": "3"
+        },
+        "required_balance_rat": [ [ 1, [ 3 ] ], [ 1, [ 1000 ] ] ],
+        "coin": "ETH"
+      },
+      {
+        "amount": "0.00325",
+        "amount_fraction": {
+          "denom": "4000",
+          "numer": "13"
+        },
+        "amount_rat": [ [ 0, [ 13 ] ], [ 1, [ 4000 ] ] ],
+        "required_balance": "0.00325",
+        "required_balance_fraction": {
+          "denom": "4000",
+          "numer": "13"
+        },
+        "required_balance_rat": [ [ 0, [ 13 ] ], [ 1, [ 4000 ] ] ],
+        "coin": "QTUM"
+      }
+    ]
+  },
+  "id": 0
+}
+```
+
+#### Response (NotSufficientBalance error)
+
+```json
+{
+  "mmrpc": "2.0",
+  "error": "Not enough BTC for swap: available 0.000015, required at least 0.10012, locked by swaps None",
+  "error_path": "maker_swap",
+  "error_trace": "maker_swap:1540] maker_swap:1641]",
+  "error_type": "NotSufficientBalance",
+  "error_data": {
+    "coin":"BTC",
+    "available":"0.000015",
+    "required":"0.10012",
+    "locked_by_swaps":"0"
+  },
+  "id": 0
+}
+```
+
+#### Response (VolumeTooLow error)
+
+```json
+{
+  "mmrpc": "2.0",
+  "error":"The volume 0.00001 of the RICK coin less than minimum transaction amount 0.0001",
+  "error_path": "maker_swap",
+  "error_trace": "maker_swap:1599]",
+  "error_type": "VolumeTooLow",
+  "error_data": {
+    "coin": "RICK",
+    "volume": "0.00001",
+    "threshold": "0.0001"
+  },
+  "id": 0
+}
+```
+
+#### Response (Transport error)
+
+```json
+{
+  "mmrpc": "2.0",
+  "error": "Transport error: JsonRpcError { client_info: 'coin: tBTC', request: JsonRpcRequest { jsonrpc: '2.0', id: '31', method: 'blockchain.estimatefee', params: [Number(1), String('ECONOMICAL')] }, error: Transport('rpc_clients:1237] rpc_clients:1239] ['rpc_clients:2047] common:1385] future timed out']') }",
+  "error_path": "taker_swap.utxo_common",
+  "error_trace": "taker_swap:1599] utxo_common:1990] utxo_common:166]",
+  "error_type": "Transport",
+  "error_data": "JsonRpcError { client_info: 'coin: tBTC', request: JsonRpcRequest { jsonrpc: '2.0', id: '31', method: 'blockchain.estimatefee', params: [Number(1), String('ECONOMICAL')] }, error: Transport('rpc_clients:1237] rpc_clients:1239] ['rpc_clients:2047] common:1385] future timed out']') }",
+  "id": 0
+}
+```

--- a/docs/basic-docs/atomicdex/atomicdex-api-20/withdraw.md
+++ b/docs/basic-docs/atomicdex/atomicdex-api-20/withdraw.md
@@ -1,0 +1,452 @@
+# withdraw
+
+The `withdraw` method generates, signs, and returns a transaction that transfers the `amount` of `coin` to the address indicated in the `to` argument.
+
+This method generates a raw transaction which should then be broadcast using [send_raw_transaction](../../../basic-docs/atomicdex/atomicdex-api.html#send-raw-transaction).
+
+### Arguments
+
+| Structure     | Type             | Description                                                                                                                               |
+| ------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| coin          | string           | the name of the coin the user desires to withdraw                                                                                         |
+| to            | string           | coins are withdrawn to this address                                                                                                       |
+| amount        | string (numeric) | the amount the user desires to withdraw, ignored when `max=true`                                                                          |
+| max           | bool             | withdraw the maximum available amount                                                                                                     |
+| fee.type      | string           | type of transaction fee; possible values: `UtxoFixed`, `UtxoPerKbyte`, `EthGas`                                                           |
+| fee.amount    | string (numeric) | fee amount in coin units, used only when type is `UtxoFixed` (fixed amount not depending on tx size) or `UtxoPerKbyte` (amount per Kbyte) |
+| fee.gas_price | string (numeric) | used only when fee type is EthGas; sets the gas price in `gwei` units                                                                     |
+| fee.gas       | number (integer) | used only when fee type is EthGas; sets the gas limit for transaction                                                                     |
+
+### Response
+
+| Structure         | Type             | Description                                                                                                                                                                   |
+| ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| from              | array of strings | coins are withdrawn from this address; the array contains a single element, but transactions may be sent from several addresses (UTXO coins)                                  |
+| to                | array of strings | coins are withdrawn to this address; this may contain the `my_address` address, where change from UTXO coins is sent                                                          |
+| my_balance_change | string (numeric) | the expected balance of change in `my_address` after the transaction broadcasts                                                                                               |
+| received_by_me    | string (numeric) | the amount of coins received by `my_address` after the transaction broadcasts; the value may be above zero when the transaction requires that MM2 send change to `my_address` |
+| spent_by_me       | string (numeric) | the amount of coins spent by `my_address`; this value differ from the request amount, as the transaction fee is added here                                                    |
+| total_amount      | string (numeric) | the total amount of coins transferred                                                                                                                                         |
+| fee_details       | object           | the fee details of the generated transaction; this value differs for utxo and ETH/ERC20 coins, check the examples for more details                                            |
+| tx_hash           | string           | the hash of the generated transaction                                                                                                                                         |
+| tx_hex            | string           | transaction bytes in hexadecimal format; use this value as input for the `send_raw_transaction` method                                                                        |
+
+### :warning: Error types
+
+#### NotSufficientBalance
+
+The `available` balance is not sufficient to transfer the specified amount.
+
+| Structure | Type             | Description                                                                                                                                            |
+| --------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| coin      | string           | the name of the coin which balance is not sufficient. This coin name may differ from the requested coin. For example, ERC20 fees are paid by ETH (gas) |
+| available | string (numeric) | the balance available for transfer                                                                                                                     |
+| required  | string (numeric) | the amount required to transfer the specified amount. This amount is necessary but may not be sufficient                                               |
+
+#### ZeroBalanceToWithdrawMax
+
+The available balance is zero.
+
+| Structure | Type | Description |
+| --------- | ---- | ----------- |
+| (none)    |      |             |
+
+#### AmountTooLow
+
+The specified amount is too low. Required at least `threshold`.
+
+| Structure | Type             | Description                                          |
+| --------- | ---------------- | ---------------------------------------------------- |
+| amount    | string (numeric) | the amount the user was willing to transfer          |
+| threshold | string (numeric) | the `amount` has not to be less than the `threshold` |
+
+#### InvalidAddress
+
+The specified `to` address is not valid.
+
+| Structure | Type   | Description           |
+| --------- | ------ | --------------------- |
+| (none)    | string | the error description |
+
+#### InvalidFeePolicy
+
+The specified `fee` is not valid.
+
+| Structure | Type   | Description           |
+| --------- | ------ | --------------------- |
+| (none)    | string | the error description |
+
+#### NoSuchCoin
+
+The specified coin was not found or is not activated yet.
+
+| Structure | Type   | Description                                   |
+| --------- | ------ | --------------------------------------------- |
+| coin      | string | the not found `coin` specified in the Request |
+
+#### Transport
+
+The request was failed due to a network error.
+
+| Structure | Type   | Description                     |
+| --------- | ------ | ------------------------------- |
+| (none)    | string | the transport error description |
+
+#### InternalError
+
+The request was failed due to a MarketMaker internal error.
+
+| Structure | Type   | Description                    |
+| --------- | ------ | ------------------------------ |
+| (none)    | string | the internal error description |
+
+### :pushpin: Examples
+
+#### Command (BTC, KMD, and other BTC-based forks)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"userpass\":\"$userpass\",\"mmrpc\":\"2.0\",\"method\":\"withdraw\",\"params\":{\"coin\":\"KMD\",\"to\":\"RJTYiYeJ8eVvJ53n2YbrVmxWNNMVZjDGLh\",\"amount\":\"10\"},\"id\":0}"
+```
+
+#### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "block_height":0,
+    "coin":"ETOMIC",
+    "fee_details":{
+      "type":"Utxo",
+      "amount":"0.00001"
+    },
+    "from":[
+      "R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"
+    ],
+    "my_balance_change":"-10.00001",
+    "received_by_me":"0.34417325",
+    "spent_by_me":"10.34418325",
+    "to":[
+      "RJTYiYeJ8eVvJ53n2YbrVmxWNNMVZjDGLh"
+    ],
+    "total_amount":"10.34418325",
+    "tx_hash":"3a1c382c50a7d12e4675d12ed7e723ce9f0167693dd75fd772bae8524810e605",
+    "tx_hex":"0400008085202f890207a8e96978acfb8f0d002c3e4390142810dc6568b48f8cd6d8c71866ad8743c5010000006a47304402201960a7089f2d93480fff68ce0b7ca7bb7a32a52915753ac7ae780abd6162cb1d02202c9b11d442e5f72a532f44ceb10122898d486b1474a10eb981c60c5538b9c82d012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff97f56bf3b0f815bb737b7867e71ddb8198bba3574bb75737ba9c389a4d08edc6000000006a473044022055199d80bd7e2d1b932e54f097c6a15fc4b148d21299dc50067c1da18045f0ed02201d26d85333df65e6daab40a07a0e8a671af9d9b9d92fdf7d7ef97bd868ca545a012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff0200ca9a3b000000001976a91464ae8510aac9546d5e7704e31ce177451386455588acad2a0d02000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac00000000000000000000000000000000000000"
+  },
+  "id":0
+}
+```
+
+#### Response (NotSufficientBalance error)
+
+```json
+{
+  "mmrpc":"2.0",
+  "error":"Not enough RICK to withdraw: available 69.75066225, required at least 1000.00001",
+  "error_path":"utxo_common",
+  "error_trace":"utxo_common:1379] utxo_common:449]",
+  "error_type":"NotSufficientBalance",
+  "error_data":{
+    "coin":"RICK",
+    "available":"69.75066225",
+    "required":"1000.00001"
+  },
+  "id":0
+}
+```
+
+#### Command (BTC, KMD, and other BTC-based forks, fixed fee)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"RICK\",\"to\":\"R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW\",\"amount\":\"1.0\",\"fee\":{\"type\":\"UtxoFixed\",\"amount\":\"0.1\"}},\"id\":0}"
+```
+
+#### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "tx_hex":"0400008085202f8901ef25b1b7417fe7693097918ff90e90bba1351fff1f3a24cb51a9b45c5636e57e010000006b483045022100b05c870fcd149513d07b156e150a22e3e47fab4bb4776b5c2c1b9fc034a80b8f022038b1bf5b6dad923e4fb1c96e2c7345765ff09984de12bbb40b999b88b628c0f9012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff0200e1f505000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ac8cbaae5f010000001976a91405aab5342166f8594baf17a7d9bef5d56744332788ace87a5e5d000000000000000000000000000000",
+    "tx_hash":"1ab3bc9308695960bc728fa427ac00d1812c4ae89aaa714c7618cb96d111be58",
+    "from":[
+      "R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"
+    ],
+    "to":[
+      "R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"
+    ],
+    "total_amount":"60.10253836",
+    "spent_by_me":"60.10253836",
+    "received_by_me":"60.00253836",
+    "my_balance_change":"-0.1",
+    "block_height":0,
+    "timestamp":1566472936,
+    "fee_details":{
+      "type":"Utxo",
+      "amount":"0.1"
+    },
+    "coin":"RICK",
+    "internal_id":""
+  },
+  "id":0
+}
+```
+
+#### Response (InvalidFeePolicy error - attempt to use EthGas for UTXO coin)
+
+```json
+{
+  "mmrpc":"2.0",
+  "error":"Invalid fee policy: Expected 'UtxoFixed' or 'UtxoPerKbyte' fee types, found EthGas",
+  "error_path":"utxo_common",
+  "error_trace":"utxo_common:1371]",
+  "error_type":"InvalidFeePolicy",
+  "error_data":"Expected 'UtxoFixed' or 'UtxoPerKbyte' fee types, found EthGas",
+  "id":0
+}
+```
+
+#### Command (BTC, KMD, and other BTC-based forks, 1 RICK per Kbyte)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"RICK\",\"to\":\"R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW\",\"amount\":\"1.0\",\"fee\":{\"type\":\"UtxoPerKbyte\",\"amount\":\"1\"}},\"id\":0}"
+```
+
+#### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "tx_hex":"0400008085202f890258be11d196cb18764c71aa9ae84a2c81d100ac27a48f72bc6059690893bcb31a000000006b483045022100ef11280e981be280ca5d24c947842ca6a8689d992b73e3a7eb9ff21070b0442b02203e458a2bbb1f2bf8448fc47c51485015904a5271bb17e14be5afa6625d67b1e8012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff58be11d196cb18764c71aa9ae84a2c81d100ac27a48f72bc6059690893bcb31a010000006b483045022100daaa10b09e7abf9d4f596fc5ac1f2542b8ecfab9bb9f2b02201644944ddc0280022067aa1b91ec821aa48f1d06d34cd26fb69a9f27d59d5eecdd451006940d9e83db012102031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3ffffffff0200e1f505000000001976a91405aab5342166f8594baf17a7d9bef5d56744332788acf31c655d010000001976a91405aab5342166f8594baf17a7d9bef5d56744332788accd7c5e5d000000000000000000000000000000",
+    "tx_hash":"fd115190feec8c0c14df2696969295c59c674886344e5072d64000379101b78c",
+    "from":[
+      "R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"
+    ],
+    "to":[
+      "R9o9xTocqr6CeEDGDH6mEYpwLoMz6jNjMW"
+    ],
+    "total_amount":"60.00253836",
+    "spent_by_me":"60.00253836",
+    "received_by_me":"59.61874931",
+    "my_balance_change":"-0.38378905",
+    "block_height":0,
+    "timestamp":1566473421,
+    "fee_details":{
+      "type":"Utxo",
+      "amount":"0.38378905"
+    },
+    "coin":"RICK",
+    "internal_id":""
+  },
+  "id":0
+}
+```
+
+#### Command (ETH, ERC20, and other ETH-based forks)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"ETH\",\"to\":\"0xbab36286672fbdc7b250804bf6d14be0df69fa28\",\"amount\":10},\"id\":0}"
+```
+
+#### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "block_height":0,
+    "coin":"ETH",
+    "fee_details":{
+      "type":"Eth",
+      "coin":"ETH",
+      "gas":21000,
+      "gas_price":"0.000000001",
+      "total_fee":"0.000021"
+    },
+    "from":[
+      "0xbab36286672fbdc7b250804bf6d14be0df69fa29"
+    ],
+    "my_balance_change":"-10.000021",
+    "received_by_me":"0",
+    "spent_by_me":"10.000021",
+    "to":[
+      "0xbab36286672fbdc7b250804bf6d14be0df69fa28"
+    ],
+    "total_amount":"10.000021",
+    "tx_hash":"8fbc5538679e4c4b78f8b9db0faf9bf78d02410006e8823faadba8e8ae721d60",
+    "tx_hex":"f86d820a59843b9aca0082520894bab36286672fbdc7b250804bf6d14be0df69fa28888ac7230489e80000801ba0fee87414a3b40d58043a1ae143f7a75d7f47a24e872b638281c448891fd69452a05b0efcaed9dee1b6d182e3215d91af317d53a627404b0efc5102cfe714c93a28"
+  },
+  "id":0
+}
+```
+
+#### Command (ETH, ERC20, and other ETH-based forks, with gas fee)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"$1\",\"to\":\"$2\",\"amount\":\"$3\",\"fee\":{\"type\":\"EthGas\",\"gas_price\":\"3.5\",\"gas\":55000}},\"id\":0}"
+```
+
+#### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "tx_hex":"f86d820b2884d09dc30082d6d894bab36286672fbdc7b250804bf6d14be0df69fa29888ac7230489e80000801ca0ef0167b0e53ed50d87b6fd630925f2bce6ee72e9b5fdb51c6499a7caaecaed96a062e5cb954e503ff83f2d6ce082649fdcdf8a77c8d37c7d26d46d3f736b228d10",
+    "tx_hash":"a26c4dcacf63c04e385dd973ca7e7ca1465a3b904a0893bcadb7e37681d38c95",
+    "from":[
+      "0xbAB36286672fbdc7B250804bf6D14Be0dF69fa29"
+    ],
+    "to":[
+      "0xbAB36286672fbdc7B250804bf6D14Be0dF69fa29"
+    ],
+    "total_amount":"10",
+    "spent_by_me":"10.0001925",
+    "received_by_me":"10",
+    "my_balance_change":"-0.0001925",
+    "block_height":0,
+    "timestamp":1566474670,
+    "fee_details":{
+      "type":"Eth",
+      "coin":"ETH",
+      "gas":55000,
+      "gas_price":"0.0000000035",
+      "total_fee":"0.0001925"
+    },
+    "coin":"ETH",
+    "internal_id":""
+  },
+  "id":0
+}
+```
+
+#### Response (InvalidFeePolicy error - attempt to use UtxoFixed or UtxoPerKbyte for ETH coin)
+
+```json
+{
+  "mmrpc":"2.0",
+  "error":"Invalid fee policy: Expected 'EthGas' fee type, found UtxoFixed",
+  "error_path":"eth",
+  "error_trace":"eth:535]",
+  "error_type":"InvalidFeePolicy",
+  "error_data":"Expected 'EthGas' fee type, found UtxoFixed",
+  "id":0
+}
+```
+
+#### Command (max = true)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"ETH\",\"to\":\"0xbab36286672fbdc7b250804bf6d14be0df69fa28\",\"max\":true},\"id\":0}"
+```
+
+##### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "block_height":0,
+    "coin":"ETH",
+    "fee_details":{
+      "type":"Eth",
+      "coin":"ETH",
+      "gas":21000,
+      "gas_price":"0.000000001",
+      "total_fee":"0.000021"
+    },
+    "from":[
+      "0xbab36286672fbdc7b250804bf6d14be0df69fa29"
+    ],
+    "my_balance_change":"-10.000021",
+    "received_by_me":"0",
+    "spent_by_me":"10.000021",
+    "to":[
+      "0xbab36286672fbdc7b250804bf6d14be0df69fa28"
+    ],
+    "total_amount":"10.000021",
+    "tx_hash":"8fbc5538679e4c4b78f8b9db0faf9bf78d02410006e8823faadba8e8ae721d60",
+    "tx_hex":"f86d820a59843b9aca0082520894bab36286672fbdc7b250804bf6d14be0df69fa28888ac7230489e80000801ba0fee87414a3b40d58043a1ae143f7a75d7f47a24e872b638281c448891fd69452a05b0efcaed9dee1b6d182e3215d91af317d53a627404b0efc5102cfe714c93a28"
+  },
+  "id":0
+}
+```
+
+##### Command (QRC20)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"QRC20\",\"to\":\"qHmJ3KA6ZAjR9wGjpFASn4gtUSeFAqdZgs\",\"amount\":10},\"id\":0}"
+```
+
+##### Response (success)
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "block_height":0,
+    "coin":"QRC20",
+    "timestamp":1608725061,
+    "fee_details":{
+      "type":"Qrc20",
+      "coin":"tQTUM",
+      "miner_fee":"0.00000447",
+      "gas_limit":100000,
+      "gas_price":40,
+      "total_gas_fee":"0.04"
+    },
+    "from":[
+      "qXxsj5RtciAby9T7m98AgAATL4zTi4UwDG"
+    ],
+    "my_balance_change":"-10",
+    "received_by_me":"0",
+    "spent_by_me":"10",
+    "to":[
+      "qHmJ3KA6ZAjR9wGjpFASn4gtUSeFAqdZgs"
+    ],
+    "total_amount":"10",
+    "tx_hash":"8fbc5538679e4c4b78f8b9db0faf9bf78d02410006e8823faadba8e8ae721d60",
+    "tx_hex":"f86d820a59843b9aca0082520894bab36286672fbdc7b250804bf6d14be0df69fa28888ac7230489e80000801ba0fee87414a3b40d58043a1ae143f7a75d7f47a24e872b638281c448891fd69452a05b0efcaed9dee1b6d182e3215d91af317d53a627404b0efc5102cfe714c93a28"
+  },
+  "id":0
+}
+```
+
+##### Command (QRC20, with gas fee)
+
+```bash
+curl --url "http://127.0.0.1:7783" --data "{\"mmrpc\":\"2.0\",\"userpass\":\"$userpass\",\"method\":\"withdraw\",\"params\":{\"coin\":\"QRC20\",\"to\":\"qHmJ3KA6ZAjR9wGjpFASn4gtUSeFAqdZgs\",\"amount\":10,\"fee\":{\"type\":\"Qrc20Gas\",\"gas_limit\":250000,\"gas_price\":40}},\"id\":0}"
+```
+
+```json
+{
+  "mmrpc":"2.0",
+  "result":{
+    "block_height":0,
+    "coin":"QRC20",
+    "timestamp":1608725061,
+    "fee_details":{
+      "type":"Qrc20",
+      "coin":"tQTUM",
+      "miner_fee":"0.00000447",
+      "gas_limit":250000,
+      "gas_price":40,
+      "total_gas_fee":"0.1"
+    },
+    "from":[
+      "qXxsj5RtciAby9T7m98AgAATL4zTi4UwDG"
+    ],
+    "my_balance_change":"-10",
+    "received_by_me":"0",
+    "spent_by_me":"10",
+    "to":[
+      "qHmJ3KA6ZAjR9wGjpFASn4gtUSeFAqdZgs"
+    ],
+    "total_amount":"10",
+    "tx_hash":"8fbc5538679e4c4b78f8b9db0faf9bf78d02410006e8823faadba8e8ae721d60",
+    "tx_hex":"f86d820a59843b9aca0082520894bab36286672fbdc7b250804bf6d14be0df69fa28888ac7230489e80000801ba0fee87414a3b40d58043a1ae143f7a75d7f47a24e872b638281c448891fd69452a05b0efcaed9dee1b6d182e3215d91af317d53a627404b0efc5102cfe714c93a28"
+  },
+  "id":0
+}
+```

--- a/docs/basic-docs/atomicdex/atomicdex-api.md
+++ b/docs/basic-docs/atomicdex/atomicdex-api.md
@@ -38,7 +38,7 @@ The `numerator` and `denominator` are BigInteger numbers represented as a sign a
 
 ## batch requests
 
-A batch request is a method for sending several unique requests to the network all at once. 
+A batch request is a method for sending several unique requests to the network all at once.
 
 The requests are sent as an array filled with request objects. Results are returned in the order of received requests.
 
@@ -1812,7 +1812,7 @@ This amount should be multiplied by 2 and deducted from the volume on `buy/sell`
 
 ::: tip
 
-This function is deprecated. Use the **trade_preimage** instead.
+This function is deprecated. Please consider using [trade_preimage v2.0](../../../basic-docs/atomicdex/atomicdex-api-20/trade_preimage.html) instead.
 
 :::
 
@@ -5793,7 +5793,7 @@ The `stop` method stops the MM2 software.
 | --------- | ---- | ----------- |
 | (none)    |      |             |
 
-## trade\_preimage
+## trade\_preimage (deprecated)
 
 **trade_preimage**
 
@@ -5814,6 +5814,12 @@ Use the resulting `volume` as an argument of the `buy` or `sell` requests.
 ::: warning Important
 
 Use the `trade_preimage` request with `max = true` and `swap_method = "setprice"` arguments to approximate the fee amounts **only**. Do not use the resulting `volume` as an argument of the `setprice`.
+
+:::
+
+::: tip
+
+This function is deprecated. Please consider using [trade_preimage v2.0](../../../basic-docs/atomicdex/atomicdex-api-20/trade_preimage.html) instead.
 
 :::
 


### PR DESCRIPTION
* Add 'trade_preimage' and 'withdraw' RPC functions to the 'AtomicDEX API 2.0' section
* Up-to-date the 'trade_preimage' examples (add 'paid_from_trading_vol', add 'required_balance' to 'total_fees')